### PR TITLE
Refactored Zoomcompass setting 

### DIFF
--- a/voyage-45/src/components/Map.js
+++ b/voyage-45/src/components/Map.js
@@ -20,12 +20,11 @@ function MapBox({ data }) {
             projection: "mercator",
             center: [60, 25],
             zoom: 1, 
-            // cooperativeGestures: true,
-            touchZoomRotate: { enableRotation: false }
+            cooperativeGestures: true,
         });
 
         // add navigation control (the +/- zoom buttons)
-        map.addControl(new mapboxgl.NavigationControl());
+        map.addControl(new mapboxgl.NavigationControl({showCompass:false, showZoom:true}));
 
         map.on('load', () => {
             // Add data to the map as a source


### PR DESCRIPTION
Took off the compass button and ensured the map function requires using the control or command key while scrolling to zoom the map, and panning on touch devices requires using two fingers to pan the map.  

<img width="650" alt="Screenshot 2023-08-27 at 3 45 58 PM" src="https://github.com/chingu-voyages/v45-tier2-team-28/assets/3441200/0810b276-b96d-4358-bfa9-ab86a5ae8984">


